### PR TITLE
Use 0xff as delimiter between topic and body of the key

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -209,6 +210,9 @@ func (srv *Server) register(msg protocol.Register) (protocol.RegisterResponse, e
 	}
 	if time.Duration(msg.TTL) > longestTTL {
 		return protocol.RegisterResponse{Status: protocol.E_INVALID_TTL}, nil
+	}
+	if bytes.IndexByte([]byte(msg.Topic), TopicBodyDelimiter) != -1 {
+		return protocol.RegisterResponse{Status: protocol.E_INVALID_NAMESPACE}, nil
 	}
 	if !msg.Record.Signed() {
 		return protocol.RegisterResponse{Status: protocol.E_INVALID_ENR}, nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -108,6 +108,14 @@ func TestRegisterRPC(t *testing.T) {
 			},
 		},
 		{
+			Desc:   "has0xff",
+			Status: protocol.E_INVALID_NAMESPACE,
+			Request: protocol.Register{
+				TTL:   uint64(longestTTL - 1),
+				Topic: string([]byte{0x01, 0x01, TopicBodyDelimiter}),
+			},
+		},
+		{
 			Desc:   "invalidenr",
 			Status: protocol.E_INVALID_ENR,
 			Request: protocol.Register{

--- a/server/storage_test.go
+++ b/server/storage_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -73,47 +74,51 @@ func TestGetRandomMultipleTimes(t *testing.T) {
 }
 
 func TestGetRandomMultiTopics(t *testing.T) {
-	first := "first"
-	second := "second"
-	firstSet := map[string]struct{}{}
-	secondSet := map[string]struct{}{}
-	memdb, _ := leveldb.Open(storage.NewMemStorage(), nil)
-	s := NewStorage(memdb)
-	for _, fixture := range []struct {
-		topic string
-		set   map[string]struct{}
-	}{
-		{first, firstSet},
-		{second, secondSet},
-	} {
-		for i := 0; i < 5; i++ {
-			key, _ := crypto.GenerateKey()
-			var r enr.Record
-			require.NoError(t, enr.SignV4(&r, key))
-			_, err := s.Add(fixture.topic, r, time.Time{})
+	for _, tc := range [][2]string{{"first", "second"}, {"first", "firstprefix"}} {
+		t.Run(fmt.Sprintf("%s!=%s", tc[0], tc[1]), func(t *testing.T) {
+			first := tc[0]
+			second := tc[1]
+			firstSet := map[string]struct{}{}
+			secondSet := map[string]struct{}{}
+			memdb, _ := leveldb.Open(storage.NewMemStorage(), nil)
+			s := NewStorage(memdb)
+			for _, fixture := range []struct {
+				topic string
+				set   map[string]struct{}
+			}{
+				{first, firstSet},
+				{second, secondSet},
+			} {
+				for i := 0; i < 5; i++ {
+					key, _ := crypto.GenerateKey()
+					var r enr.Record
+					require.NoError(t, enr.SignV4(&r, key))
+					_, err := s.Add(fixture.topic, r, time.Time{})
+					require.NoError(t, err)
+					fixture.set[crypto.PubkeyToAddress(key.PublicKey).Hex()] = struct{}{}
+				}
+			}
+			firstRecods, err := s.GetRandom(first, 5)
 			require.NoError(t, err)
-			fixture.set[crypto.PubkeyToAddress(key.PublicKey).Hex()] = struct{}{}
-		}
-	}
-	firstRecods, err := s.GetRandom(first, 5)
-	require.NoError(t, err)
-	require.Len(t, firstRecods, 5)
-	for _, r := range firstRecods {
-		var id enr.Secp256k1
-		require.NoError(t, r.Load(&id))
-		addr := crypto.PubkeyToAddress(ecdsa.PublicKey(id))
-		assert.Contains(t, firstSet, addr.Hex())
-		assert.NotContains(t, secondSet, addr.Hex())
-	}
-	secondRecods, err := s.GetRandom(second, 5)
-	require.NoError(t, err)
-	require.Len(t, secondRecods, 5)
-	for _, r := range secondRecods {
-		var id enr.Secp256k1
-		require.NoError(t, r.Load(&id))
-		addr := crypto.PubkeyToAddress(ecdsa.PublicKey(id))
-		assert.Contains(t, secondSet, addr.Hex())
-		assert.NotContains(t, firstSet, addr.Hex())
+			require.Len(t, firstRecods, 5)
+			for _, r := range firstRecods {
+				var id enr.Secp256k1
+				require.NoError(t, r.Load(&id))
+				addr := crypto.PubkeyToAddress(ecdsa.PublicKey(id))
+				assert.Contains(t, firstSet, addr.Hex())
+				assert.NotContains(t, secondSet, addr.Hex())
+			}
+			secondRecods, err := s.GetRandom(second, 5)
+			require.NoError(t, err)
+			require.Len(t, secondRecods, 5)
+			for _, r := range secondRecods {
+				var id enr.Secp256k1
+				require.NoError(t, r.Load(&id))
+				addr := crypto.PubkeyToAddress(ecdsa.PublicKey(id))
+				assert.Contains(t, secondSet, addr.Hex())
+				assert.NotContains(t, firstSet, addr.Hex())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Isolation was broken for topics that are prefix of another topic.
For example, if there is topic 0x01 and topic 0x01,0x02 - all requests
for topic 0x01 will include records from last topic. We will use 0xff as a delimiter
between topic and body.