### PR TITLE
Add prometheus metrics to rendezvous server

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,6 +15,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:ad4589ec239820ee99eb01c1ad47ebc5f8e02c4f5103a9b210adff9696d89f36"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "T"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
+  branch = "master"
   digest = "1:4acc913dcb78404a44ae8901da9b990ef6d5c12ece04504ab3a68e46c2f3f0ce"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
@@ -85,6 +93,14 @@
   pruneopts = "T"
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:a2ecb56e5053d942aafc86738915fb94c9131bac848c543b8b6764365fd69080"
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  pruneopts = "T"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -476,6 +492,14 @@
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:a8e3d14801bed585908d130ebfc3b925ba642208e6f30d879437ddfc7bb9b413"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "T"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:130cefe87d7eeefc824978dcb78e35672d4c49a11f25c153fbf0cfd952756fa3"
   name = "github.com/minio/blake2b-simd"
@@ -556,6 +580,50 @@
   pruneopts = "T"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:982a7f214f928ef1fcef5c098a0bf2f7ced1a55afc3826c4efb081312fb42624"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "T"
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:185cf55b1f44a1bf243558901c3f06efa5c64ba62cfdcbb1bf7bbe8c3fb68561"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "T"
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:957ed2f869f3628d455cff7cf44b5a42ddb44f4127b58a2abe84c912aa3c0d81"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "T"
+  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
+
+[[projects]]
+  branch = "master"
+  digest = "1:a0bf4ff9047d70facb760fd1c830e8c06bd1fc04e9a8b50e03f5c67a062c157b"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "T"
+  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
   digest = "1:ff6b0586c0621a76832cf783eee58cbb9d9795d2ce8acbc199a4131db11c42a9"
@@ -774,6 +842,8 @@
     "github.com/libp2p/go-libp2p-net",
     "github.com/libp2p/go-libp2p-peer",
     "github.com/multiformats/go-multiaddr",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/spf13/pflag",
     "github.com/status-im/go-multiaddr-ethv4",
     "github.com/stretchr/testify/assert",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -69,3 +69,7 @@
 [[constraint]]
   name = "github.com/gyuho/goraph"
   version = "2.0.0"
+
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  version = "0.8.0"

--- a/server/cleaner.go
+++ b/server/cleaner.go
@@ -59,6 +59,13 @@ func (c *Cleaner) Add(deadline time.Time, key string) {
 	heap.Push(c, key)
 }
 
+func (c *Cleaner) Exist(key string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, exist := c.deadlines[key]
+	return exist
+}
+
 func (c *Cleaner) PopOneSince(now time.Time) (rst string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,35 @@
+package server
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	registerationsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "active_registrations",
+		Namespace: "rendezvous",
+		Help:      "Number of active unique registrations.",
+	}, []string{"topic"})
+
+	discoverySize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:      "discovery_size",
+		Namespace: "rendezvous",
+		Buckets:   []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		Help:      "Number of records found for each discover requests.",
+	}, []string{"topic"})
+
+	discoveryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:      "discovery_duration",
+		Namespace: "rendezvous",
+		Help:      "Discovery requests in seconds.",
+		Buckets:   []float64{0.1, 0.2, 0.5, 1, 2, 5, 10},
+	}, []string{"topic"})
+
+	errorsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:      "discovery_errors",
+		Namespace: "rendezvous",
+		Help:      "Number of errors labeled by the type of operation.",
+	}, []string{"operation"})
+)
+
+func init() {
+	prometheus.MustRegister(registerationsGauge, discoverySize, discoveryDuration)
+}

--- a/server/storage.go
+++ b/server/storage.go
@@ -22,6 +22,16 @@ type StorageRecord struct {
 	Time time.Time
 }
 
+// TopicPart looks for TopicBodyDelimiter and returns topic prefix from the same key.
+// It doesn't allocate memory for topic prefix.
+func TopicPart(key []byte) []byte {
+	idx := bytes.IndexByte(key, TopicBodyDelimiter)
+	if idx == -1 {
+		return nil
+	}
+	return key[:idx]
+}
+
 type RecordsKey []byte
 
 func NewRecordsKey(topic string, record enr.Record) RecordsKey {


### PR DESCRIPTION
Four different metrics to track rendezvous discovery server behavior.

`discovery_errors` is a counter to track how often error occurs. It can have 3 different labels; register, discover, and unkown. The last one is assigned if  server received unknown request identifier.

`active_registrations` is a gauge. Active registration means every unique registration that is stored in the database. Increments when unique topic/identity pair was received. And decrements if it wasn't updated during TTL period and removed from storage.

`discovery_duration` is a histogram with time that it takes to process discover request. This is somewhat complicated logic of the app, as we seek random prefix and it can take some time. Labeled with topic.

`discovery_size` is a histogram with a number of records found for each discover request. Labeled with topic.

By default metrics will be exposed on the `http://127.0.01:8080/metrics`. To change listening address please use:
```
-m, --metrics-address string   http server for exposing prometheus metrics (default "127.0.0.1:8080")
```