### PR TITLE
Fix several issues with counting removal of they keys with topic

### DIFF
--- a/server/cleaner.go
+++ b/server/cleaner.go
@@ -72,6 +72,12 @@ func (c *Cleaner) PopOneSince(now time.Time) (rst string) {
 	if len(c.heap) == 0 {
 		return
 	}
+	// same key can be inserted multiple times into the heap,
+	// deadline for a key is removed when it was popped the first time
+	if _, exist := c.deadlines[c.heap[0]]; !exist {
+		heap.Pop(c)
+		return
+	}
 	if now.After(c.deadlines[c.heap[0]]) {
 		return heap.Pop(c).(string)
 	}

--- a/server/cleaner_test.go
+++ b/server/cleaner_test.go
@@ -14,7 +14,10 @@ func TestCleaner(t *testing.T) {
 		added[ttl] = ttl.String()
 		c.Add(time.Time{}.Add(ttl), ttl.String())
 	}
-	assert.Equal(t, added[time.Minute], c.PopOneSince(time.Time{}.Add(90*time.Second)))
+	c.Add(time.Time{}.Add(91*time.Second), time.Minute.String())
+	assert.Empty(t, c.PopOneSince(time.Time{}.Add(90*time.Second)))
+	assert.Equal(t, added[time.Minute], c.PopOneSince(time.Time{}.Add(92*time.Second)))
+	assert.Empty(t, c.PopOneSince(time.Time{}.Add(92*time.Second)))
 	assert.Len(t, c.heap, 2)
 	assert.Empty(t, c.PopOneSince(time.Time{}.Add(119*time.Second)))
 	assert.Equal(t, added[2*time.Minute], c.PopOneSince(time.Time{}.Add(121*time.Second)))

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -31,5 +31,5 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(registerationsGauge, discoverySize, discoveryDuration)
+	prometheus.MustRegister(registerationsGauge, discoverySize, discoveryDuration, errorsCounter)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -34,6 +34,7 @@ func TestCleanOnRegister(t *testing.T) {
 			memdb, _ := leveldb.Open(storage.NewMemStorage(), nil)
 			s := NewStorage(memdb)
 			srv := NewServer(nil, nil, s)
+			srv.networkDelay = 0
 			srv.cleanerPeriod = 10 * time.Millisecond
 			require.Nil(t, srv.Addr())
 			require.NoError(t, srv.startCleaner())

--- a/server/storage.go
+++ b/server/storage.go
@@ -29,7 +29,7 @@ func TopicPart(key []byte) []byte {
 	if idx == -1 {
 		return nil
 	}
-	return key[:idx]
+	return key[1:idx] // first byte is RecordsPrefix
 }
 
 type RecordsKey []byte


### PR DESCRIPTION
Removal was counted multiple times and first byte wasn't stripped from the key stored in the cleaner, as it is used for isolation. Full key is a BUCKET BYTE + TOPIC + DELIMITER + RECORD BYTES.